### PR TITLE
Sheets api read optimization

### DIFF
--- a/functions/drive_api.py
+++ b/functions/drive_api.py
@@ -19,7 +19,7 @@ from absl import logging
 from googleapiclient import discovery
 from googleapiclient import errors
 from googleapiclient import http
-import requests
+import httpx
 
 
 # The format of Drive URL
@@ -50,7 +50,7 @@ class DriveService:
       file_id = self.extract_file_id(url)
       return self._download_drive_asset(file_id)
     else:
-      response = requests.get(url)
+      response = httpx.get(url)
     return io.BytesIO(response.content).read()
 
   def extract_file_id(self, image_url: str) -> str:

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -9,4 +9,4 @@ pillow==10.3.0
 functions-framework==3.3.0
 validators==0.28.2
 pytest == 8.1.1
-urllib3<2.0.0
+httpx==0.27.0

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -9,3 +9,4 @@ pillow==10.3.0
 functions-framework==3.3.0
 validators==0.28.2
 pytest == 8.1.1
+urllib3<2.0.0

--- a/functions/sheet_api.py
+++ b/functions/sheet_api.py
@@ -972,13 +972,27 @@ class SheetsService:
         results, data_references.SheetNames.customers, "!B:B", account_map
     )
 
+    # Pre-fetch existing campaign IDs before the loop
+    existing_campaigns = self.get_sheet_values(
+        data_references.SheetNames.campaigns + "!D:D"
+    )
+    existing_campaigns_set = {
+        str(val[0]) for val in existing_campaigns if val
+    }
+
     for row in results:
       customer_id = str(row.customer_client.id)
 
       if customer_id:
-        results = self.google_ads_service.retrieve_all_campaigns(customer_id)
+        results = self.google_ads_service.retrieve_all_campaigns(
+            customer_id
+        )
         account_map = self.update_sheet_lists(
-            results, data_references.SheetNames.campaigns, "!D:D", account_map
+            results,
+            data_references.SheetNames.campaigns,
+            "!D:D",
+            account_map,
+            existing_campaigns_set,
         )
 
     return account_map
@@ -990,16 +1004,27 @@ class SheetsService:
     )
     account_map = self.refresh_campaign_list()
 
+    # Pre-fetch existing asset group IDs before the loop
+    existing_asset_groups = self.get_sheet_values(
+        data_references.SheetNames.asset_groups + "!F:F"
+    )
+    existing_asset_groups_set = {
+        str(val[0]) for val in existing_asset_groups if val
+    }
+
     for row in results:
       customer_id = str(row.customer_client.id)
 
       if customer_id:
-        results = self.google_ads_service.retrieve_all_asset_groups(customer_id)
+        results = (
+            self.google_ads_service.retrieve_all_asset_groups(customer_id)
+        )
         self.update_sheet_lists(
             results,
             data_references.SheetNames.asset_groups,
             "!F:F",
             account_map,
+            existing_asset_groups_set,
         )
 
   def refresh_assets_list(self) -> None:
@@ -1055,6 +1080,7 @@ class SheetsService:
       sheet_name: str,
       column: str,
       account_map: Mapping[str, Mapping[str, str]],
+      existing_values_set: set[str] = None,
   ) -> Mapping[str, Mapping[str, str]]:
     """Write exisitng customer list, campaigns, asset groups, assets and sitelinks to spreadsheet.
 
@@ -1064,8 +1090,12 @@ class SheetsService:
       sheet_name: Name of the sheet to write the results to.
       column: String value representation of sheet column, with unique id.
       account_map: Google Ads account map, account ids and names.
+      existing_values_set: Optional set of existing IDs to avoid duplicates.
     """
-    existing_values = self.get_sheet_values(sheet_name + column)
+    if existing_values_set is None:
+      existing_values = self.get_sheet_values(sheet_name + column)
+      existing_values_set = {str(val[0]) for val in existing_values if val}
+
     sheet_range = ""
     sheet_output = []
     index = 0
@@ -1091,7 +1121,7 @@ class SheetsService:
         row_item_id = str(row.asset_group.id)
         sheet_range = sheet_name + "!A:F"
 
-      if [row_item_id] not in existing_values:
+      if row_item_id not in existing_values_set:
         sheet_output.append([])
         sheet_output[index] = self.generate_list_sheet_output(row, sheet_name)
 

--- a/terraform/cloud_function.tf
+++ b/terraform/cloud_function.tf
@@ -57,6 +57,7 @@ resource "google_cloudfunctions2_function" "function" {
   build_config {
     runtime     = "python312"
     entry_point = "pmax_trigger" # Set the entry entry_point
+    service_account = google_service_account.service_account.id
     source {
       storage_source {
         bucket = google_storage_bucket.cf_upload_bucket.name


### PR DESCRIPTION
1. Optimized Sheets API reads (Pre-fetching and caching IDs using sets to avoid slow list lookups and duplicate reads).
- This is a fix for timeouts with new AssetGroup creation.

2. Fixed Cloud Function deployment permissions (Added the custom service account in Terraform's build config).

3. Fixed external image download crashes (Switched from requests to httpx).
- Looking for feedback on this one. After a new deployment the external image fetching was crashing. My research returned httpx best practice. Switching it worked.